### PR TITLE
add wordnet nltk helpers

### DIFF
--- a/ovos_classifiers/datasets/wordnet.py
+++ b/ovos_classifiers/datasets/wordnet.py
@@ -1,0 +1,124 @@
+import nltk
+from nltk.corpus import wordnet as wn
+
+
+class Wordnet:
+    nltk.download("wordnet")
+    nltk.download('omw-1.4')
+
+    @staticmethod
+    def get_synsets(word, pos=wn.NOUN):
+        synsets = wn.synsets(word, pos=pos)
+        if not len(synsets):
+            return []
+        return synsets
+
+    @staticmethod
+    def get_definition(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return synset.definition()
+
+    @staticmethod
+    def get_examples(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return synset.examples()
+
+    @staticmethod
+    def get_lemmas(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return [l.name().replace("_", " ") for l in synset.lemmas()]
+
+    @staticmethod
+    def get_hypernyms(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return [l.name().split(".")[0].replace("_", " ") for l in
+                synset.hypernyms()]
+
+    @staticmethod
+    def get_hyponyms(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return [l.name().split(".")[0].replace("_", " ") for l in
+                synset.hyponyms()]
+
+    @staticmethod
+    def get_holonyms(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return [l.name().split(".")[0].replace("_", " ") for l in
+                synset.member_holonyms()]
+
+    @staticmethod
+    def get_root_hypernyms(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        return [l.name().split(".")[0].replace("_", " ") for l in
+                synset.root_hypernyms()]
+
+    @staticmethod
+    def common_hypernyms(word, word2, pos=wn.NOUN):
+        synsets = wn.synsets(word, pos=pos)
+        if not len(synsets):
+            return []
+        synset = synsets[0]
+        synsets = wn.synsets(word2, pos=pos)
+        if not len(synsets):
+            return []
+        synset2 = synsets[0]
+        return [l.name().split(".")[0].replace("_", " ") for l in
+                synset.lowest_common_hypernyms(synset2)]
+
+    @staticmethod
+    def get_antonyms(word, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(word, pos=pos)
+            if not len(synsets):
+                return []
+            synset = synsets[0]
+        lemmas = synset.lemmas()
+        if not len(lemmas):
+            return []
+        lemma = lemmas[0]
+        antonyms = lemma.antonyms()
+        return [l.name().split(".")[0].replace("_", " ") for l in antonyms]
+
+    @classmethod
+    def query(cls, query, pos=wn.NOUN, synset=None):
+        if synset is None:
+            synsets = wn.synsets(query, pos=pos)
+            if not len(synsets):
+                return {}
+            synset = synsets[0]
+        res = {"lemmas": cls.get_lemmas(query, pos=pos, synset=synset),
+               "antonyms": cls.get_antonyms(query, pos=pos, synset=synset),
+               "holonyms": cls.get_holonyms(query, pos=pos, synset=synset),
+               "hyponyms": cls.get_hyponyms(query, pos=pos, synset=synset),
+               "hypernyms": cls.get_hypernyms(query, pos=pos, synset=synset),
+               "root_hypernyms": cls.get_root_hypernyms(query, pos=pos, synset=synset),
+               "definition": cls.get_definition(query, pos=pos, synset=synset)}
+        return res

--- a/ovos_classifiers/opm.py
+++ b/ovos_classifiers/opm.py
@@ -1,10 +1,15 @@
+import random
 from typing import Optional, List
 
-from ovos_plugin_manager.templates.transformers import UtteranceTransformer
+from nltk.corpus import wordnet as wn
 from ovos_classifiers.corefiob import OVOSCorefIOBTagger
-from ovos_classifiers.postag import OVOSPostag
+from ovos_classifiers.datasets.wordnet import Wordnet
 from ovos_classifiers.heuristics.normalize import Normalizer, CatalanNormalizer, CzechNormalizer, \
     PortugueseNormalizer, AzerbaijaniNormalizer, RussianNormalizer, EnglishNormalizer, UkrainianNormalizer
+from ovos_classifiers.postag import OVOSPostag
+
+from ovos_plugin_manager.templates.solvers import QuestionSolver
+from ovos_plugin_manager.templates.transformers import UtteranceTransformer
 
 
 class UtteranceNormalizer(UtteranceTransformer):
@@ -39,7 +44,8 @@ class UtteranceNormalizer(UtteranceTransformer):
         context = context or {}
         lang = context.get("lang") or self.config.get("lang", "en-us")
         normalizer = self.get_normalizer(lang)
-        norm = [normalizer.normalize(u) for u in utterances]
+        norm = [normalizer.normalize(u) for u in utterances] + \
+               [normalizer.normalize(u, remove_articles=True) for u in utterances]
         norm = [self.strip_punctuation(u) for u in norm]
         return list(set(norm + utterances)), context
 
@@ -69,8 +75,104 @@ class CoreferenceNormalizer(UtteranceTransformer):
         return list(set(utterances)), context
 
 
+class WordnetSolver(QuestionSolver):
+    enable_tx = True
+    priority = 80
+
+    def __init__(self, config=None):
+        config = config or {}
+        config["lang"] = "en"  # only english supported
+        super(WordnetSolver, self).__init__(config)
+
+    def extract_keyword(self, query, lang="en"):
+        query = query.lower()
+
+        # regex from narrow to broader matches
+        match = None
+        if lang == "en":
+            # TODO - keyword extractor class / localization
+            starts = ["who is ", "what is ", "when is ", "tell me about "]
+            for s in starts:
+                if query.startswith(s):
+                    return query.split(s)[-1]
+        return None
+
+    def get_data_key(self, query, lang="en"):
+        # TODO localization
+        if lang == "en":
+            query = self.extract_keyword(query, lang) or query
+            words = query.split()
+
+            stop_words = ["the", "on", "of", "in", "a", "is", "what", "when", "for", "an", "at"]
+            if any("antonym" in w for w in words):
+                query = " ".join(w for w in words
+                                 if "antonym" not in w
+                                 and w not in stop_words)
+                return "antonyms", query
+
+            if any("synonym" in w for w in words):
+                query = " ".join(w for w in words
+                                 if "synonym" not in w
+                                 and w not in stop_words)
+                return "lemmas", query
+
+            if any("definition" in w or "meaning" in w for w in words) or words[0] == "what":
+                query = " ".join(w for w in words
+                                 if "definition" not in w and "meaning" not in w
+                                 and w not in stop_words)
+                return "definition", query
+
+        return None, query
+
+    # officially exported Solver methods
+    def get_data(self, query, context=None):
+        pos = wn.NOUN  # TODO check context for postag
+        synsets = wn.synsets(query, pos=pos)
+        if not len(synsets):
+            return {}
+        synset = synsets[0]
+        res = {"lemmas": Wordnet.get_lemmas(query, pos=pos, synset=synset),
+               "antonyms": Wordnet.get_antonyms(query, pos=pos, synset=synset),
+               "holonyms": Wordnet.get_holonyms(query, pos=pos, synset=synset),
+               "hyponyms": Wordnet.get_hyponyms(query, pos=pos, synset=synset),
+               "hypernyms": Wordnet.get_hypernyms(query, pos=pos, synset=synset),
+               "root_hypernyms": Wordnet.get_root_hypernyms(query, pos=pos, synset=synset),
+               "definition": Wordnet.get_definition(query, pos=pos, synset=synset)}
+        return res
+
+    def get_spoken_answer(self, query, context=None):
+        lang = context.get("lang") or self.default_lang
+        lang = lang.split("-")[0]
+        # extract the best keyword with some regexes or fallback to RAKE
+        k, query = self.get_data_key(query, lang)
+        if not query:
+            query = self.extract_keyword(query, lang) or query
+        data = self.search(query, context)
+        if k and k in data:
+            v = data[k]
+            if k in ["lemmas", "antonyms"] and len(v):
+                return random.choice(v)
+            if isinstance(v, list) and len(v):
+                v = v[0]
+            if isinstance(v, str):
+                return v
+        # definition
+        return data.get("definition")
+
+
 if __name__ == "__main__":
+    d = WordnetSolver()
+    sentence = d.spoken_answer("what is the definition of computer")
+    print(sentence)
+    # a machine for performing calculations automatically
+
+    d = WordnetSolver()
+    sentence = d.spoken_answer("qual é a definição de computador", lang="pt")
+    print(sentence)
+    # uma máquina para realizar cálculos automaticamente
+
     u, _ = UtteranceNormalizer().transform(["Mom is awesome, she said she loves me!"])
-    print(u) # ['Mom is awesome , she said she loves me', 'Mom is awesome, she said she loves me']
-    u, _ = CoreferenceNormalizer().transform(u) #
-    print(u) # ['Mom is awesome , Mom said Mom loves me', 'Mom is awesome , she said she loves me', 'Mom is awesome, she said she loves me']
+    print(u)  # ['Mom is awesome , she said she loves me', 'Mom is awesome, she said she loves me']
+    u, _ = CoreferenceNormalizer().transform(u)  #
+    print(
+        u)  # ['Mom is awesome , Mom said Mom loves me', 'Mom is awesome , she said she loves me', 'Mom is awesome, she said she loves me']

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ PLUGIN_ENTRY_POINT = (
     'ovos-utterance-normalizer=ovos_classifiers.opm:UtteranceNormalizer',
     'ovos-utterance-coref-normalizer=ovos_classifiers.opm:CoreferenceNormalizer'
 )
-
+SOLVER_ENTRY_POINT = 'ovos-question-solver-wordnet=ovos_classifiers.opm:WordnetSolver'
 
 setup(
     name='ovos-classifiers',
@@ -89,6 +89,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     entry_points={
-        'neon.plugin.text': PLUGIN_ENTRY_POINT
+        'neon.plugin.text': PLUGIN_ENTRY_POINT,
+        'neon.plugin.solver': SOLVER_ENTRY_POINT
     }
 )


### PR DESCRIPTION
wordnet dataset helper class + opm solver plugin

adapted from https://github.com/NeonGeckoCom/neon-solver-plugin-wordnet , removing as many dependencies as possible (simplematch)

(note, lang plugins setup assumed to be done before hand in config and plugins installed, libretranslate by default)

since this package already provides dataset wrappers and heuristics, as well as a wordnet lemmatizer, it makes sense to provide the baseline solvers for each nlp task introduced in https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/148 here

this also brings basic "what is XXX" support for [persona](https://github.com/OpenVoiceOS/ovos-core/issues/297)