### PR TITLE
ordinal check is_number_de

### DIFF
--- a/ovos_classifiers/heuristics/numeric.py
+++ b/ovos_classifiers/heuristics/numeric.py
@@ -332,6 +332,9 @@ class GermanNumberParser:
             return False
 
     def is_number_de(self, word: str):
+        if self.is_ordinal_de(word):
+            return None
+
         if is_numeric(word):
             if word.isdigit():
                 return int(word)


### PR DESCRIPTION
Unnoticed bug where ordinals are analyzed as number (DE), resulting in a float normalization

ie. `12.` -> `12.0`