### PR TITLE
license tests

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(precise-runner|fann2|tqdm|bs4|mutagen|chardet|ovos-stt-plugin).*'
+          exclude: '^(chardet).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(chardet).*'
+          exclude: '^(chardet|text-unidecode).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -1,0 +1,44 @@
+name: Run License Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  license_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Build Tools
+        run: |
+          python -m pip install build wheel
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install python3-dev swig libssl-dev
+      - name: Install repo
+        run: |
+          pip install .
+      - name: Get explicit and transitive dependencies
+        run: |
+          pip freeze > requirements-all.txt
+      - name: Check python
+        id: license_check_report
+        uses: pilosus/action-pip-license-checker@v0.5.0
+        with:
+          requirements: 'requirements-all.txt'
+          fail: 'Copyleft,Other,Error'
+          fails-only: true
+          exclude: '^(precise-runner|fann2|tqdm|bs4|mutagen|chardet|ovos-stt-plugin).*'
+          exclude-license: '^(Mozilla).*$'
+      - name: Print report
+        if: ${{ always() }}
+        run: echo "${{ steps.license_check_report.outputs.report }}"

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -37,7 +37,7 @@ jobs:
           requirements: 'requirements-all.txt'
           fail: 'Copyleft,Other,Error'
           fails-only: true
-          exclude: '^(chardet|text-unidecode).*'
+          exclude: '^(chardet|text-unidecode|tqdm).*'
           exclude-license: '^(Mozilla).*$'
       - name: Print report
         if: ${{ always() }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyahocorasick
 normality
 ovos-config
 quebra-frases
+PyICU


### PR DESCRIPTION
allow `chardet` and `text-unidecode` in license tests  (copyleft)

dragged by the lib `normality`

`chardet` is only used in a single util function in `normality.encoding` that ovos does not depend on, ovos-classifiers only imports `normality.transliteration`

`normality.transliteration` is the best alternative for unicode handling that does not drag `unidecode` and complies with our licensing policy

as long as we do not use `guess_file_encoding` from `normality.encoding` we are only depending on MIT code, not on `chardet`

`text-unidecode` only used as a fallback if PyICU is missing,  but PyICU is a dependency of ovos-classifiers to ensure it isnt used