### PR TITLE
drop PyICU

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pyahocorasick
 normality
 ovos-config
 quebra-frases
-PyICU


### PR DESCRIPTION
optional and causes install issues if the system library isnt present